### PR TITLE
package.json: main path fixed to work with case sensitive filesystems

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": {
     "name": "Luuk de Vlieger"
   },
-  "main": "dist/Color.js",
+  "main": "dist/color.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/luukdv/color.js.git"


### PR DESCRIPTION
package.json uses "dist/Color.js" for main, but the file is actually "dist/color.js". This probably works on OSX, but it fails on case sensitive filesystems (like most/all Linux systems).

I'd love a version bump and push to npm if you had a moment. Thanks!